### PR TITLE
Use curly-brace syntax for substitutes

### DIFF
--- a/src/ambients_ast.js
+++ b/src/ambients_ast.js
@@ -10,7 +10,7 @@ function parameterDeclaration(names) {
 function variableExpression(name) {
   this.name = name
   this.type = types.toUnknownType(name)
-  this.toAmbient = () => `${this.name}[]`
+  this.toAmbient = () => `{${this.name}}[]`
 }
 
 function returnExpression(expr) {
@@ -90,7 +90,7 @@ function functionDefinition (name, body) {
   this.toAmbient = () => {
     return ambient(name,
       seq('write_ (init)', parallel(
-        ':init',
+        '{init}[]',
         body.toAmbient()
       ))
     )

--- a/test/fixtures/js/new_encoding/006-new-function-encodings.ambient
+++ b/test/fixtures/js/new_encoding/006-new-function-encodings.ambient
@@ -1,12 +1,12 @@
 a[
   write_ (init).(
-    :init|
+    {init}[]|
     write_ (x).read_ (x)
   )
 ]|
 b[
   write_ (init).(
-    :init|
+    {init}[]|
     write_ (fn, x).write (fn, x).read_ (fn, fn_r0).(
       fn_r0[]|
       read_ (fn_r0)

--- a/test/fixtures/js/new_encoding/007-string-concat.ambient
+++ b/test/fixtures/js/new_encoding/007-string-concat.ambient
@@ -1,6 +1,6 @@
 a[
   write_ (init).(
-    :init|
+    {init}[]|
     write_ ().(
       string[
         plus[
@@ -14,12 +14,12 @@ a[
 ]|
 b[
   write_ (init).(
-    :init|
+    {init}[]|
     write_ (x).(
       string[
         plus[
           l[string[hello[]]]|
-          r[x[]]
+          r[{x}[]]
         ]
       ]|
       read_ (string)
@@ -28,7 +28,7 @@ b[
 ]|
 c[
   write_ (init).(
-    :init|
+    {init}[]|
     write_ (x).(
       string[
         plus[
@@ -36,7 +36,7 @@ c[
             string[
               plus[
                 l[string[hello[]]]|
-                r[x[]]
+                r[{x}[]]
               ]
             ]
           ]|
@@ -51,7 +51,7 @@ c[
 ]|
 d[
   write_ (init).(
-    :init|
+    {init}[]|
     write_ (x).(
       string[
         plus[
@@ -64,7 +64,7 @@ d[
                       l[
                         string[hello[]]
                       ]|
-                      r[x[]]
+                      r[{x}[]]
                     ]
                   ]
                 ]|
@@ -74,7 +74,7 @@ d[
               ]
             ]
           ]|
-          r[x[]]
+          r[{x}[]]
         ]
       ]|
       read_ (string)
@@ -83,7 +83,7 @@ d[
 ]|
 e[
   write_ (init).(
-    :init|
+    {init}[]|
     write_ (x, y).(
       string[
         plus[
@@ -91,11 +91,11 @@ e[
             string[
               plus[
                 l[string[hello[]]]|
-                r[x[]]
+                r[{x}[]]
               ]
             ]
           ]|
-          r[y[]]
+          r[{y}[]]
         ]
       ]|
       read_ (string)
@@ -104,12 +104,12 @@ e[
 ]|
 f[
   write_ (init).(
-    :init|
+    {init}[]|
     write_ (x, y).(
       string[
         plus[
-          l[x[]]|
-          r[y[]]
+          l[{x}[]]|
+          r[{y}[]]
         ]
       ]|
       read_ (string)
@@ -118,12 +118,12 @@ f[
 ]|
 g[
  write_ (init).(
-   :init|
+   {init}[]|
    write_ (x).(
      string[
        plus[
-         l[x[]]|
-         r[x[]]
+         l[{x}[]]|
+         r[{x}[]]
        ]
      ]|
      read_ (string)
@@ -132,23 +132,23 @@ g[
 ]|
 h[
   write_ (init).(
-    :init|
+    {init}[]|
     write_ (x, y, z).(
       string[
         plus[
           l[
             string[
               plus[
-                l[x[]]|
-                r[y[]]
+                l[{x}[]]|
+                r[{y}[]]
               ]
             ]
           ]|
           r[
             string[
               plus[
-                l[y[]]|
-                r[x[]]
+                l[{y}[]]|
+                r[{x}[]]
               ]
             ]
           ]


### PR DESCRIPTION
This PR will change the ambient syntax to use curly braces for substitutable ambients. It also changes the `init` from `:init` to `{init}[]` to be handled as an ambient substitution.